### PR TITLE
support for command line args longer than 8192 bytes

### DIFF
--- a/src/build/TSLint.MSBuild.targets
+++ b/src/build/TSLint.MSBuild.targets
@@ -1,6 +1,32 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <UsingTask TaskName="ExecDirect" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll" >
+    <ParameterGroup>
+      <Command ParameterType="System.String" Required="true" />
+      <Arguments ParameterType="System.String" Required="true" />
+      <ExitCode ParameterType="System.Int32" Output="true" />
+      <ConsoleOutput ParameterType="System.String" Output="true" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System"/>
+      <Using Namespace="System.Diagnostics"/>
+      <Code Type="Fragment" Language="cs">
+        var process = new Process();
+        process.StartInfo.FileName = Command;
+        process.StartInfo.Arguments = Arguments;
+        process.StartInfo.CreateNoWindow = true;
+        process.StartInfo.UseShellExecute = false;
+        process.StartInfo.RedirectStandardOutput = true;
+        process.Start();
+        process.WaitForExit();
+        ExitCode = process.ExitCode;
+        ConsoleOutput = process.StandardOutput.ReadToEnd();
+        Log.LogError(ConsoleOutput);
+      </Code>
+    </Task>
+  </UsingTask>
+
   <Target
     AfterTargets="CompileTypeScript"
 	Condition="('@(TSLintInclude)' != '' or '@(TypeScriptCompile)' != '') and ('$(BuildingProject)' == 'true' or '$(TSLintRunWhenNotBuilding)' == 'true')"
@@ -9,7 +35,7 @@
     Outputs="$([System.DateTime]::UtcNow.Ticks)">
 
 	<Message Text="Running TSLint..." Importance="high" />
-	
+
     <ItemGroup Condition="'$(TSLintExcludeTypeScriptCompile)' != 'true'">
       <TSLintInclude Include="@(TypeScriptCompile)" />
     </ItemGroup>
@@ -56,16 +82,12 @@
     <Error Condition="'$(TSLintFileListDisabled)' == 'true' And '$(TSLintProject)' == ''" Text="You disabled file listing on the command line using TSLintFileDisabled, but did not specify a project file with TSLintProject." />
 
     <!-- Run TSLint using the Node executable -->
-    <Exec
-      Command="&quot;$(TSLintNodeExe)&quot; &quot;$(TSLintCli)&quot; $(TSLintArgs)"
-      Condition="'$(TSLintDisabled)' != 'true'"
-      ConsoleToMsBuild="true"
-      EchoOff="true"
-      IgnoreExitCode="true"
-      Timeout="$(TSLintTimeout)">
-      <Output TaskParameter="ConsoleOutput" ItemName="TSLintOutput" />
-      <Output TaskParameter="ExitCode" PropertyName="TSLintErrorCode" />
-    </Exec>
+    <ExecDirect
+        Command="&quot;$(TSLintNodeExe)&quot;"
+        Arguments="&quot;$(TSLintCli)&quot; $(TSLintArgs)">
+        <Output TaskParameter="ConsoleOutput" PropertyName="TSLintOutput" />
+        <Output TaskParameter="ExitCode" PropertyName="TSLintErrorCode" />
+    </ExecDirect>
 
     <!-- Return an error if TSLint returned an exit code and we should break on errors -->
     <Error Condition="'$(TSLintErrorCode)' != '0' and '$(TSLintBreakBuildOnError)' == 'true'" Text="TSLint failed" />


### PR DESCRIPTION
This is solving issue with cmd.exe limitation for 8192 bytes of the command line.