### PR TITLE
no error if empty output (in some cases)

### DIFF
--- a/src/build/TSLint.MSBuild.targets
+++ b/src/build/TSLint.MSBuild.targets
@@ -21,8 +21,11 @@
         process.Start();
         process.WaitForExit();
         ExitCode = process.ExitCode;
-        ConsoleOutput = process.StandardOutput.ReadToEnd();
-        Log.LogError(ConsoleOutput);
+        ConsoleOutput = process.StandardOutput.ReadToEnd().Trim('\r', '\n');
+        if (!string.IsNullOrWhiteSpace(ConsoleOutput))
+        {
+          Log.LogError(ConsoleOutput);
+        }
       </Code>
     </Task>
   </UsingTask>


### PR DESCRIPTION
In some cases we get empty error in MS Build, even though there is no lint errors